### PR TITLE
fix: 手动传 apiUrl 时 callback 未正确自动携带

### DIFF
--- a/packages/components/map/index.vue
+++ b/packages/components/map/index.vue
@@ -348,10 +348,13 @@
         ? Object.assign(proxy!.$baiduMapPluginsSourceLink, props.pluginsSourceLink)
         : props.pluginsSourceLink || proxy!.$baiduMapPluginsSourceLink || {}
     const scriptKey = apiUrl ? `_initBMap_` : `_initBMap_${ak}`
+    const src = apiUrl
+      ? `${apiUrl.replace(/&$/, '')}&callback=${scriptKey}`
+      : `//api.map.baidu.com/api?type=webgl&v=1.0&ak=${ak}&callback=${scriptKey}`
 
     // load sdk
     getScriptAsync({
-      src: apiUrl ? apiUrl : `//api.map.baidu.com/api?type=webgl&v=1.0&ak=${ak}&callback=${scriptKey}`,
+      src,
       addCalToWindow: true,
       key: scriptKey,
       exportGetter: () => window.BMapGL


### PR DESCRIPTION
在 electron 中使用 [`protocol.registerSchemesAsPrivileged`](https://www.electron.js.cn/docs/latest/api/protocol#protocolregisterschemesasprivilegedcustomschemes) 将自定义协议注册为标准协议（例如 foo），在尝试访问资源地址 `//api.map.baidu.com/api` 时，会将该网络请求解析为 `foo://api.map.baidu.com/api`，导致 `apiUrl` 未能被正确加载。

所以需要手动传入 `apiUrl`，但 `scriptKey` 默认值 `_initBMap_` 未被携带到传入的 `apiUrl` 的`callback` 上，导致资源未能正确加载，虽然可以在传入的 apiUrl 上设置 `&callback=_initBMap_`，但不推荐。

```ts
app.use(baiduMapInit, {
  // ak: 'cwHsf5i2fAQAlijOyELx5COtkFhItaSm',
  apiUrl: 'https://api.map.baidu.com/api?type=webgl&v=1.0&ak=cwHsf5i2fAQAlijOyELx5COtkFhItaSm',
})
```